### PR TITLE
Fix positive cash flow display on financial page

### DIFF
--- a/client/src/pages/FinancialsPage.tsx
+++ b/client/src/pages/FinancialsPage.tsx
@@ -1,11 +1,12 @@
 import PageLayout from "@/components/layout/PageLayout";
 import SimpleChart from "@/components/charts/SimpleChart";
 import { Card } from "@/components/ui/card";
-import { getFinancialProjections } from "@/lib/businessData";
+import { getFinancialProjections, getKeyMetrics } from "@/lib/businessData";
 import { TrendingUp, DollarSign, PiggyBank, Target } from "lucide-react";
 
 export default function FinancialsPage() {
   const financialData = getFinancialProjections();
+  const keyMetrics = getKeyMetrics();
   
   // Prepare different chart datasets
   const revenueData = financialData.map(item => ({ month: item.month, value: item.revenue }));
@@ -17,7 +18,9 @@ export default function FinancialsPage() {
   const totalRevenue = financialData.reduce((sum, item) => sum + item.revenue, 0);
   const finalProfit = financialData[financialData.length - 1].profit;
   const breakEvenMonth = financialData.findIndex(item => item.profit > 0) + 1;
-  const positiveFlowMonth = financialData.findIndex(item => item.cashFlow > 0) + 1;
+  const positiveFlowMonth = Number(
+    keyMetrics.find((m) => m.label === "Положительный Cash Flow")?.value ?? 0
+  );
 
   return (
     <PageLayout>


### PR DESCRIPTION
## Summary
- Read positive cash flow month from shared key metrics
- Ensure the finance dashboard displays the correct value of 9 months

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'finalCashFlow' does not exist, missing exports)*

------
https://chatgpt.com/codex/tasks/task_b_68a2127de65883308e45acdfd5235b20